### PR TITLE
Fix bug when dealing with leading zeroes in time

### DIFF
--- a/src/shalarm.sh
+++ b/src/shalarm.sh
@@ -857,9 +857,9 @@ fi
 
 ##  Print how much time is left until the alarm
 get_current_time
-leastSecond=$(( ($alarmHour - $currentHour) * 60 * 60 + \
-                ($alarmMinute - $currentMinute) * 60 + \
-                ($alarmSecond - $currentSecond) ))
+leastSecond=$(( (10#$alarmHour - $currentHour) * 60 * 60 + \
+                (10#$alarmMinute - $currentMinute) * 60 + \
+                (10#$alarmSecond - $currentSecond) ))
 if [[ $leastSecond -lt 0 ]]; then
     leastSecond=$(( $leastSecond + 60 * 60 * 24 ))
 fi


### PR DESCRIPTION
### Problem
Bash supposes ``$(( 09 ))`` to be not valid since it is not a valid octal notation. Thus, when you give the script such time like 08:09 or so, it fails
### Solution
We need to remove leading zero. Stackoverflow: [link](https://stackoverflow.com/questions/11123717/removing-leading-zeros-before-passing-the-variable-to-iptables)