### PR TITLE
Fix default sound file being used even when soundfile set by user

### DIFF
--- a/data/shalarm.cfg
+++ b/data/shalarm.cfg
@@ -42,8 +42,12 @@ mediaPlayerOptions=DEFAULT
 #
 #   This is the sound file played by the alarm.  It can be the default ring wav,
 #   a song somewhere on your harddrive, whatever.
+#   If not using DEFAULT findSoundFile must be set to 0.
 #-------------------------------------------------------------------------------
 soundFile=DEFAULT
+
+#findSoundFile=0
+
 #soundFile="/path/to/soundFile.wav"     ##  NOTE:  Use quotes around the path
 #soundFile="/path/to/song.mp3"
 


### PR DESCRIPTION
Changing the `soundfile` in `shalarm.cfg` had no effect because `findSoundFile` was always set to `1`.
As that was the case `find_sound_file` was called every time setting `soundFile` back to its default value.
I have added a comment in `shalarm.cfg` recommending setting `findSoundFile` to `0` if changing the value of `soundFile,` thus solving the issue.